### PR TITLE
Add static-land-pull-stream to interop

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -69,6 +69,7 @@
 * pull-stream/pull-stream-to-stream
 * queckezz/pull-promise
 * jamen/pull-await
+* rjmk/static-land-pull-stream
 
 # crypto
 


### PR DESCRIPTION
Defines functions for using pull streams with the Static Land spec
