### PR TITLE
Add jamen/pull-vinyl

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -44,6 +44,7 @@
 * ipfs/interface-pull-blob-store
 * ipfs/js-fs-pull-blob-store
 * ipfs/js-idb-pull-blob-store
+* jamen/pull-vinyl
 
 # text
 


### PR DESCRIPTION
I've created [`pull-vinyl`](https://github.com/jamen/pull-vinyl), inspired from [`vinyl-fs`](https://github.com/gulpjs/gulp).

Example:

``` js
var pull = require('pull-stream')
var vinyl = require('pull-vinyl')

pull(
  // Read `Vinyl` object from the file system.
  vinyl.src('app/**/*.js'),

  // Do transforms here

  // Then write to a base folder:
  vinyl.dest('out')
)
```
