### PR TITLE
Add jamen/pull-fs-meta

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -45,6 +45,7 @@
 * ipfs/js-fs-pull-blob-store
 * ipfs/js-idb-pull-blob-store
 * jamen/pull-vinyl
+* jamen/pull-fs-meta
 
 # text
 


### PR DESCRIPTION
Hello, back with another module, [`pull-fs-meta`](https://github.com/jamen/pull-fs-meta).  This one is experimental, but seems to be pretty cool so far.  It's my approach to an `fs` module on `pull-stream`.

It appears to operate much like `Vinyl`inside `gulp`, except it actually just streams the file contents, and manages the metadata behind the scenes.  That way you can have reusable `pull-*` modules that compile contents (like `pull-css`) operate like a build system with this, without need to create wrappers and whatnot:

``` js
var fs = require('pull-fs-meta')()
var css = require('pull-css')

pull(
  // Read file contents:
  fs.read('out/*.css'),
  // Parse contents as CSS:
  css(),
  // Then transform AST, like PostCSS
  // Stringify it after transformed:
  css.stringify(),
  // And write out
  fs.write('out')
)
```
