### PR TITLE
add pull-cont

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -26,6 +26,7 @@
 * regular/pull-generate
 * nichoth/pull-combine-latest
 * nichoth/pull-scan
+* dominictarr/pull-cont
 
 # real-time
 


### PR DESCRIPTION
Turns a continuable into a pull-stream.

This is an easier way to make a pull-stream source where an async thing must happen first (contrasting with pull-defer)

Also, was thinking that continuables might be a really good warm up for pull-stream-workshop,
since you get to have a function that returns a function, etc, but without much else.