### PR TITLE
Add pull-file-reader

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -51,6 +51,7 @@
 * ipfs/js-idb-pull-blob-store
 * jamen/pull-vinyl
 * dominictarr/multiblob
+* tableflip/pull-file-reader
 
 # text
 


### PR DESCRIPTION
Given an HTML5 File object (from e.g. HTML5 drag and drops), turn it into a pull stream source.