### PR TITLE
Add jdvorak/pull-offset-limit

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -34,6 +34,7 @@
 * elavoie/pull-eager-buffer
 * amsross/pull-fmap
 * nichoth/pull-flat-merge
+* jdvorak/pull-offset-limit
 
 
 # real-time


### PR DESCRIPTION
Adding to module list:
> A pull-stream that filters until X elements, and stops streaming after Y elements. Useful for naive pagination.

