### PR TITLE
Add pull-files

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -57,6 +57,7 @@
 * jamen/pull-vinyl
 * dominictarr/multiblob
 * tableflip/pull-file-reader
+* jamen/pull-files
 
 # text
 


### PR DESCRIPTION
I created this module [`pull-files`](https://github.com/jamen/pull-files) as a minimal way to stream directories.

It is similar to [`pull-vinyl`](https://github.com/jamen/pull-vinyl) or [`vinyl-fs`](https://github.com/gulpjs/vinyl-fs), except the files are plain (as `{ base, relative, contents }`). It is also faster.  Reads ~2300 files from `node_modules` in little over 1/10th of a second on my machine!

Still more I want to add though.  Like a stream mode for `file.contents`, and more optimizations.