### PR TITLE
Start build tools section

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -35,7 +35,7 @@
 * amsross/pull-fmap
 * nichoth/pull-flat-merge
 * jdvorak/pull-offset-limit
-
+* jamen/pull-prop
 
 # real-time
 
@@ -57,7 +57,6 @@
 * jamen/pull-vinyl
 * dominictarr/multiblob
 * tableflip/pull-file-reader
-* jamen/pull-files
 
 # text
 
@@ -99,6 +98,7 @@
 * jamen/pull-await
 * rjmk/static-land-pull-stream
 * jamen/babel-plugin-pull
+* jamen/pull-spawn-process
 
 # crypto
 
@@ -122,4 +122,8 @@
 
 * elavoie/pull-probe
 
+# build tools
 
+* jamen/pull-files
+* jamen/pull-bundle
+* jamen/pull-uglify


### PR DESCRIPTION
I'm starting some packages that are related to each other, for using pull-stream as a build tool.  Although, they are still usable in general pull-stream context.

So, I thought I would make a new section "build tools" starting with:

 - [`pull-files`](https://github.com/jamen/pull-files): Reading and writing directories of files
 - [`pull-bundle`](https://github.com/jamen/pull-bundle): Bundling the files
 - [`pull-uglify`](https://github.com/jamen/pull-uglify): Uglifying the files
 - (zlib, postcss, pug, etc?)

I also added some other packages on the side:

 - [`pull-spawn-process`](https://github.com/jamen/pull-spawn-process): A convenience wrapper around `child_process.spawn`
 - [`pull-prop`](https://github.com/jamen/pull-prop): For mapping specific properties with pull-stream
