### PR TITLE
pull-recvfrom

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -89,6 +89,7 @@
 * elavoie/pull-limit
 * elavoie/pull-lend
 * elavoie/pull-lend-stream
+* reqshark/pull-recvfrom
 
 # interop
 


### PR DESCRIPTION
[`pull-recvfrom`](https://github.com/reqshark/pull-recvfrom) for doing unix datagrams like IPC on steroids:

* address format for unix datagrams is a `pathname`
* ordered and reliable delivery of udp packets on the same box
* often orders of magnitude better latency and throughput versus ip stack or tcp
* communication between applications is limited to the same host machine (osx/linux kernel)  

[`recvfrom`](https://github.com/reqshark/recvfrom) in conjunction with [`sendto`](https://github.com/reqshark/sendto) gives us a useful advantage over [`node-unix-dgram`](https://github.com/bnoordhuis/node-unix-dgram), because either the size of user buffers (in the case of `sendto`) or a number passed to `recvfrom` automatically reconfigures arbitrarily low max buf size system limits. 

one call to kernel's `setsockopt()` adjusts unix datagram maximums for linux and osx. with `sendto` you dont have to think about that because we set socket option `SO_SNDBUF`, raising the send limit size up to the size of whatever node buffer you pass :beers:

## yo try that:
```js
var pullfrom = require('pull-recvfrom')
var sockname = '/tmp/ayyyyy'
var pull = require('pull-stream')

pull(
  pullfrom(sockname, require('recvfrom')), // pass address and recvfrom to pullfrom()
  pull.drain(log)
)
function log(buf){
  console.log(buf+'')
}

var sendto = require('sendto')
setInterval(sendto, 500, sockname, Buffer('hello from sendto'))
```