### PR TITLE
add multiserver and multiblobs

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -81,6 +81,7 @@
 * DamonOehlman/pull-ws
 * pull-stream/pull-ws-server
 * ssbc/muxrpc
+* ssbc/multiserver
 * pull-stream/pull-http-server
 * regular/pull-paginated-api-request
 * jamen/pull-fetch


### PR DESCRIPTION
might as well add the most pull-streamy parts of ssb! we already have muxrpc, and shs, how can we let people miss out on content addressable storage or servers that support multiple protocols?