### PR TITLE
add pull-throttle

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -43,6 +43,7 @@
 * pull-stream/pull-pushable
 * pull-stream/pull-notify
 * pull-stream/pull-live
+* dominictarr/pull-throttle
 
 # file system and databases
 


### PR DESCRIPTION
pull-throttle lets you set a maximum rate that a pull-stream flows at, dropping items that arrive too quickly.