### PR TITLE
Add amsross/pull-tap

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -34,6 +34,7 @@
 * elavoie/pull-stream-function-to-object
 * elavoie/pull-eager-buffer
 * amsross/pull-fmap
+* amsross/pull-monad
 * nichoth/pull-flat-merge
 * jdvorak/pull-offset-limit
 * jamen/pull-prop

--- a/modules.md
+++ b/modules.md
@@ -34,7 +34,7 @@
 * elavoie/pull-stream-function-to-object
 * elavoie/pull-eager-buffer
 * amsross/pull-fmap
-* amsross/pull-monad
+* amsross/pull-tap
 * nichoth/pull-flat-merge
 * jdvorak/pull-offset-limit
 * jamen/pull-prop


### PR DESCRIPTION
Side-effectful sync and async functions for pull streams https://github.com/amsross/pull-tap

Basically just a shorthand for `map(x => (fn(x) && x) || x)` but for async also.