### PR TITLE
Add pull2chan to modules

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -104,6 +104,7 @@
 * jamen/babel-plugin-pull
 * jamen/pull-spawn-process
 * nrkn/pull-iterable
+* maackle/pull2chan
 
 # crypto
 


### PR DESCRIPTION
Adds [pull2chan](https://github.com/maackle/pull2chan), a ClojureScript library to convert between pull-streams and core.async channels